### PR TITLE
Add cursor blink

### DIFF
--- a/css/caret.css
+++ b/css/caret.css
@@ -7,3 +7,12 @@
   transition: 0.07s;
   z-index: 3;
 }
+
+.blink-caret {
+  animation: blink 1s 1s infinite;
+}
+
+@keyframes blink{
+  0%{opacity: 0;}
+  50%{opacity: 100%;}
+}

--- a/css/custom.css
+++ b/css/custom.css
@@ -1,6 +1,7 @@
 #code_editor {
   background-color: rgb(39, 39, 39);
   overflow-y: auto;
+  cursor: text;
   /* overflow-x: hidden; */
 }
 .caret {

--- a/js/caret.js
+++ b/js/caret.js
@@ -16,11 +16,13 @@ Caret.prototype = {
   },
   
   setPos : function(row, col) {
+    this.resetBlink();
+
     this.row = row;
     this.col = col;
     
     let el = this.getCharacterElementBefore();
-    let caretElement = $(`#caret_${this.page.getId()}_${this.id}`);
+    let caretElement = this.getCarretElement();
     let lineEl, linenumEl, linecodeEl;
 
     let top, left;
@@ -265,5 +267,19 @@ Caret.prototype = {
       let line_ref = _this.page.getLineRef(line_num);
       _this.setPos(line_num, line_ref.getCharCount()+1);
     }
+  },
+
+  getCarretElement: function() {
+    return $(`#caret_${this.page.getId()}_${this.id}`);
+  },
+
+  resetBlink: function() {
+    let carret = this.getCarretElement();
+    carret.removeClass("blink-caret");
+
+    // Timeout avoids continuation of blink animation
+    window.setTimeout(() => {
+      carret.addClass("blink-caret");
+    }, 500);;
   }
 }


### PR DESCRIPTION
The caret blinks when not being moved. 
When being moved or typed, the animation is restarted. The `1s` delay in animation ensures, well, delay on restart. This makes it look like the blink is paused and resumed.
This matches with the standard caret blink animation in majority of editors. 
Fixes #2 

Also changed the `cursor` for the editor to `text`.